### PR TITLE
Add unified CLI entrypoints

### DIFF
--- a/src/async-images-processing.py
+++ b/src/async-images-processing.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from core import cli_entry
+
+if __name__ == "__main__":
+    cli_entry("async")

--- a/src/core.py
+++ b/src/core.py
@@ -1,0 +1,81 @@
+import argparse
+import asyncio
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from typing import Iterable, List
+
+from images_pipeline.module1 import ImageConfig, process_image
+
+
+def _process(file: str) -> str:
+    # Demo image processing using the existing module1 utilities
+    conf = ImageConfig(width=100, height=100)
+    return f"{file}: {process_image(conf)}"
+
+
+def _serial(files: Iterable[str]) -> List[str]:
+    return [_process(f) for f in files]
+
+
+def _multithread(files: Iterable[str], workers: int) -> List[str]:
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        return list(ex.map(_process, files))
+
+
+def _multiprocess(files: Iterable[str], workers: int) -> List[str]:
+    with ProcessPoolExecutor(max_workers=workers) as ex:
+        return list(ex.map(_process, files))
+
+
+async def _async_single(file: str) -> str:
+    return _process(file)
+
+
+async def _asyncio(files: Iterable[str], workers: int) -> List[str]:
+    sem = asyncio.Semaphore(workers)
+
+    async def _task(f: str) -> str:
+        async with sem:
+            return await _async_single(f)
+
+    return await asyncio.gather(*(_task(f) for f in files))
+
+
+def _ray(files: Iterable[str], workers: int) -> List[str]:
+    import ray
+
+    @ray.remote
+    def _task(file: str) -> str:
+        return _process(file)
+
+    ray.init(ignore_reinit_error=True, num_cpus=workers)
+    try:
+        result_ids = [_task.remote(f) for f in files]
+        results = ray.get(result_ids)
+    finally:
+        ray.shutdown()
+    return results
+
+
+def process_images(files: Iterable[str], strategy: str, workers: int = 4) -> List[str]:
+    if strategy == "serial":
+        return _serial(files)
+    if strategy == "multithread":
+        return _multithread(files, workers)
+    if strategy == "multiprocess":
+        return _multiprocess(files, workers)
+    if strategy == "async":
+        return asyncio.run(_asyncio(files, workers))
+    if strategy == "ray":
+        return _ray(files, workers)
+    raise ValueError(f"Unknown strategy: {strategy}")
+
+
+def cli_entry(strategy: str) -> None:
+    parser = argparse.ArgumentParser(description="Demo image processing")
+    parser.add_argument("files", nargs="+", help="Files to process")
+    parser.add_argument("--workers", type=int, default=4, help="Worker count")
+    args = parser.parse_args()
+    results = process_images(args.files, strategy=strategy, workers=args.workers)
+    for r in results:
+        print(r)
+

--- a/src/multiprocess-images-processing.py
+++ b/src/multiprocess-images-processing.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from core import cli_entry
+
+if __name__ == "__main__":
+    cli_entry("multiprocess")

--- a/src/multithread-images-processing.py
+++ b/src/multithread-images-processing.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from core import cli_entry
+
+if __name__ == "__main__":
+    cli_entry("multithread")

--- a/src/ray-images-processing.py
+++ b/src/ray-images-processing.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from core import cli_entry
+
+if __name__ == "__main__":
+    cli_entry("ray")

--- a/src/serial-images-processing.py
+++ b/src/serial-images-processing.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from core import cli_entry
+
+if __name__ == "__main__":
+    cli_entry("serial")


### PR DESCRIPTION
## Summary
- add `core.py` with shared image processing logic
- implement mode specific CLI scripts that delegate to `core.cli_entry`
- keep example processing simple and reuse existing `module1` utilities

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855642d5af4832bb4140972f8ea8f5d