### PR TITLE
Add shared core and CLI scripts

### DIFF
--- a/src/async-images-processing.py
+++ b/src/async-images-processing.py
@@ -1,0 +1,10 @@
+from core import parse_args, run_pipeline
+
+
+def main() -> None:
+    config = parse_args("async")
+    run_pipeline(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core.py
+++ b/src/core.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+
+
+@dataclass
+class PipelineConfig:
+    """Configuration for the image processing pipeline."""
+
+    mode: str
+    debug: bool = False
+
+
+def parse_args(mode: str, args: list[str] | None = None) -> PipelineConfig:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=f"{mode} images processing pipeline")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    parsed = parser.parse_args(args)
+    return PipelineConfig(mode=mode, debug=parsed.debug)
+
+
+def setup_logger(debug: bool) -> logging.Logger:
+    """Setup a simple logger."""
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+    return logging.getLogger("images-pipeline")
+
+
+def run_pipeline(config: PipelineConfig) -> None:
+    """Run the pipeline using the provided configuration."""
+    logger = setup_logger(config.debug)
+    logger.info("Running pipeline in %s mode", config.mode)
+    # Placeholder for the actual processing implementation
+    logger.info("Pipeline completed")

--- a/src/multiprocess-images-processing.py
+++ b/src/multiprocess-images-processing.py
@@ -1,0 +1,10 @@
+from core import parse_args, run_pipeline
+
+
+def main() -> None:
+    config = parse_args("multiprocess")
+    run_pipeline(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/multithread-images-processing.py
+++ b/src/multithread-images-processing.py
@@ -1,0 +1,10 @@
+from core import parse_args, run_pipeline
+
+
+def main() -> None:
+    config = parse_args("multithread")
+    run_pipeline(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ray-images-processing.py
+++ b/src/ray-images-processing.py
@@ -1,0 +1,10 @@
+from core import parse_args, run_pipeline
+
+
+def main() -> None:
+    config = parse_args("ray")
+    run_pipeline(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/serial-images-processing.py
+++ b/src/serial-images-processing.py
@@ -1,0 +1,10 @@
+from core import parse_args, run_pipeline
+
+
+def main() -> None:
+    config = parse_args("serial")
+    run_pipeline(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add core module with shared configuration, logging and runner
- provide simple CLI entrypoints for serial, multi-thread, multi-process, async and ray modes

## Testing
- `uv run ruff check src/core.py src/*-images-processing.py`
- `uv run mypy src`
- `uv run pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_6855642d5af4832bb4140972f8ea8f5d