### PR TITLE
Implement centralized error handling

### DIFF
--- a/src/images_pipeline/core/__init__.py
+++ b/src/images_pipeline/core/__init__.py
@@ -12,6 +12,14 @@ from .logging_config import (
     get_logger,
     setup_logger,
 )
+from .exceptions import (
+    ImagesPipelineError,
+    ImageProcessingError,
+    S3Error,
+    ConfigurationError,
+    with_error_handling,
+    batch_error_handler,
+)
 from .models import ImageItem, ProcessingConfig, ProcessingResult
 
 __all__ = [
@@ -26,4 +34,10 @@ __all__ = [
     "setup_logger",
     "get_logger",
     "configure_multiprocessing_logging",
+    "ImagesPipelineError",
+    "ImageProcessingError",
+    "S3Error",
+    "ConfigurationError",
+    "with_error_handling",
+    "batch_error_handler",
 ]

--- a/src/images_pipeline/core/exceptions.py
+++ b/src/images_pipeline/core/exceptions.py
@@ -1,0 +1,57 @@
+"""Custom exceptions and error handling utilities for the images pipeline."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+from .logging_config import get_logger
+
+
+class ImagesPipelineError(Exception):
+    """Base exception for all images pipeline errors."""
+
+
+class S3Error(ImagesPipelineError):
+    """Error raised for S3 related failures."""
+
+
+class ConfigurationError(ImagesPipelineError):
+    """Error raised for invalid configuration options."""
+
+
+class ImageProcessingError(ImagesPipelineError):
+    """Error raised when processing a single image fails."""
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def with_error_handling(func: F) -> F:
+    """Wrap a function with standardized error handling."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
+        logger = get_logger("processor")
+        try:
+            return func(*args, **kwargs)
+        except ImagesPipelineError:
+            logger.error("Pipeline error", exc_info=True)
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"Unhandled error in {func.__name__}: {exc}", exc_info=True)
+            raise ImageProcessingError(str(exc)) from exc
+
+    return wrapper  # type: ignore[return-value]
+
+
+@contextmanager
+def batch_error_handler() -> Any:
+    """Context manager to wrap batch operations with error handling."""
+    try:
+        yield
+    except ImagesPipelineError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise ImageProcessingError(str(exc)) from exc

--- a/src/images_pipeline/process_images.py
+++ b/src/images_pipeline/process_images.py
@@ -9,7 +9,11 @@ Supports multiple concurrency strategies: serial, multithread, multiprocess, asy
 import sys
 import argparse
 
-from .core import ProcessingConfig, get_logger
+from .core import (
+    ProcessingConfig,
+    get_logger,
+    ImagesPipelineError,
+)
 from .processors.common import run_processing
 from .processors import (
     serial_process_batch,
@@ -19,8 +23,12 @@ from .processors import (
 )
 
 
-def parse_args():
-    """Parse command line arguments."""
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed CLI arguments.
+    """
     parser = argparse.ArgumentParser(
         description="S3 Image Processor with multiple concurrency strategies"
     )
@@ -54,8 +62,8 @@ def parse_args():
     return parser.parse_args()
 
 
-def main():
-    """Main entry point."""
+def main() -> None:
+    """Main entry point for the CLI."""
     try:
         logger = get_logger("processor")
         logger.info("Starting S3 Image Processor")
@@ -96,7 +104,11 @@ def main():
     except KeyboardInterrupt:
         logger = get_logger("processor")
         logger.warning("Processing interrupted by user.")
-    except Exception as e:
+    except ImagesPipelineError as exc:
+        logger = get_logger("processor")
+        logger.error(f"Processing failed: {exc}")
+        sys.exit(1)
+    except Exception as e:  # noqa: BLE001
         logger = get_logger("processor")
         logger.error(f"Processing failed: {e}", exc_info=True)
         sys.exit(1)

--- a/src/images_pipeline/processors/common.py
+++ b/src/images_pipeline/processors/common.py
@@ -11,6 +11,8 @@ from ..core import (
     ProcessingConfig,
     ImageItem,
     ProcessingResult,
+    ImageProcessingError,
+    with_error_handling,
     get_logger,
 )
 from ..core.image_utils import (
@@ -303,6 +305,7 @@ def process_all_batches(
     return total_processed, total_errors
 
 
+@with_error_handling
 def run_processing(
     config: ProcessingConfig,
     processor_name: str,
@@ -344,7 +347,7 @@ def run_processing(
         total_time = time.time() - start_time
         log_final_statistics(total_time, len(work_items), processed_count, error_count)
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger = get_logger("processor")
         logger.error(f"Fatal error in processing: {e}", exc_info=True)
-        raise
+        raise ImageProcessingError(str(e)) from e

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,28 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from images_pipeline.core.exceptions import (
+    ImageProcessingError,
+    with_error_handling,
+)
+
+
+@with_error_handling
+def _fail_func() -> None:
+    raise ValueError("boom")
+
+
+def test_with_error_handling_raises_image_processing_error() -> None:
+    with pytest.raises(ImageProcessingError):
+        _fail_func()
+
+
+def test_with_error_handling_logs_error() -> None:
+    with patch("images_pipeline.core.exceptions.get_logger") as mock_get_logger:
+        mock_logger = logging.getLogger("test")
+        mock_get_logger.return_value = mock_logger
+        with pytest.raises(ImageProcessingError):
+            _fail_func()
+        assert mock_get_logger.called


### PR DESCRIPTION
## Summary
- introduce custom exceptions and with_error_handling decorator
- export new utilities from core package
- hook run_processing and CLI to new error handling
- test new decorator

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e1c5cb558832bbadadc77637defd8